### PR TITLE
Fonts and Frame Rate Enforcement

### DIFF
--- a/Dark Samurai Warrior Reloaded/Dark Samurai Warrior Reloaded.vcxproj
+++ b/Dark Samurai Warrior Reloaded/Dark Samurai Warrior Reloaded.vcxproj
@@ -109,6 +109,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Dark Samurai Warrior Reloaded/common.h
+++ b/Dark Samurai Warrior Reloaded/common.h
@@ -7,6 +7,8 @@
     *(int *)0 = 0;   \
   }
 
+#define array_length(arr) (sizeof(arr) / sizeof(arr[0]))
+
 #define u8 uint8_t
 #define u16 uint16_t
 #define u32 uint32_t
@@ -18,6 +20,8 @@
 #define s64 int64_t
 
 #define BYTES_PER_PIXEL 4
+
+
 
 inline u32 bitscan_forward(u32 mask) {
   u64 result = 0;

--- a/Dark Samurai Warrior Reloaded/common.h
+++ b/Dark Samurai Warrior Reloaded/common.h
@@ -21,8 +21,6 @@
 
 #define BYTES_PER_PIXEL 4
 
-
-
 inline u32 bitscan_forward(u32 mask) {
   u64 result = 0;
   _BitScanForward(&result, mask);

--- a/Dark Samurai Warrior Reloaded/render.c
+++ b/Dark Samurai Warrior Reloaded/render.c
@@ -31,7 +31,7 @@ void draw_bitmap(LoadedBitmap *buffer, LoadedBitmap *bitmap, u32 pos_x,
     u32 *dest_pixel = (u32 *)dest_row;
     for (s32 x = 0; x < bitmap->width; x++) {
       u32 source_color_32 = *source_pixel;
-      u32 dest_color_32 = *dest_row;
+      u32 dest_color_32 = *dest_pixel;
 
       V4 source_color = v4_color_from_u32(source_color_32);
       V4 dest_color = v4_color_from_u32(dest_color_32);

--- a/Dark Samurai Warrior Reloaded/render.c
+++ b/Dark Samurai Warrior Reloaded/render.c
@@ -77,3 +77,20 @@ void draw_rectangle(LoadedBitmap *buffer, int x, int y, int width, int height,
     row += buffer->pitch;
   }
 }
+
+
+void draw_string(LoadedBitmap* buffer, Font *font, u32 x, u32 y, char* string) { 
+  char *c = string;
+  Glyph *glyphs = font->glyphs;
+  s32 current_x = x;
+  s32 current_y = y;
+  while (*c) {
+    char character = *c;
+    assert(character >= '!' && character <= '~');
+    Glyph glyph = *(glyphs + character);
+    current_x += glyph.x_pre_step;
+    draw_bitmap(buffer, glyph.bitmap, current_x, current_y - glyph.ascent);
+    current_x += glyph.advance_width;
+    c++;
+  }
+}

--- a/Dark Samurai Warrior Reloaded/render.c
+++ b/Dark Samurai Warrior Reloaded/render.c
@@ -1,7 +1,8 @@
 #pragma once
+#include "render.h"
+
 #include "common.h"
 #include "math.h"
-#include "render.h"
 
 inline V4 v4_color_from_u32(u32 color) {
   V4 result = {.r = (float)((color >> 16) & 0xFF) / 255.0f,
@@ -78,19 +79,25 @@ void draw_rectangle(LoadedBitmap *buffer, int x, int y, int width, int height,
   }
 }
 
-
-void draw_string(LoadedBitmap* buffer, Font *font, u32 x, u32 y, char* string) { 
+void draw_string(LoadedBitmap *buffer, Font *font, u32 x, u32 y, char *string) {
   char *c = string;
   Glyph *glyphs = font->glyphs;
   s32 current_x = x;
   s32 current_y = y;
   while (*c) {
     char character = *c;
-    assert(character >= '!' && character <= '~');
-    Glyph glyph = *(glyphs + character);
-    current_x += glyph.x_pre_step;
-    draw_bitmap(buffer, glyph.bitmap, current_x, current_y - glyph.ascent);
-    current_x += glyph.advance_width;
+    // TODO: handle newlines
+    if (character == '\n') {
+      current_y -= font->line_gap;
+      current_x = x;
+      c++;
+      continue;
+    }
+    if (character >= '!' && character <= '~') {
+      Glyph glyph = *(glyphs + character);
+      draw_bitmap(buffer, glyph.bitmap, current_x, current_y - glyph.ascent);
+    }
+    current_x += font->advance_width;
     c++;
   }
 }

--- a/Dark Samurai Warrior Reloaded/render.h
+++ b/Dark Samurai Warrior Reloaded/render.h
@@ -5,3 +5,14 @@ typedef struct LoadedBitmap {
   int pitch;
   void *memory;
 } LoadedBitmap;
+
+typedef struct Glyph {
+  LoadedBitmap *bitmap;
+  int advance_width;
+  int ascent;
+  int x_pre_step;
+} Glyph;
+
+typedef struct Font {
+  Glyph glyphs[128];
+} Font;

--- a/Dark Samurai Warrior Reloaded/render.h
+++ b/Dark Samurai Warrior Reloaded/render.h
@@ -8,11 +8,11 @@ typedef struct LoadedBitmap {
 
 typedef struct Glyph {
   LoadedBitmap *bitmap;
-  int advance_width;
   int ascent;
-  int x_pre_step;
 } Glyph;
 
 typedef struct Font {
   Glyph glyphs[128];
+  int advance_width;
+  int line_gap;
 } Font;


### PR DESCRIPTION
## Description
This pull requests implements basic font extraction and rendering as well as enforcing a frame rate of 60fps.

## Changes

- Added the `win32_get_glyph` procedure, which extracts the bitmap and metadata for a character given a specific font. 
- Added the `win32_load_font` procedure, which loads an entire font's bitmaps and metadata. This is meant to be called at startup.
- Added the `draw_string` procedure, which draws a string of text on the buffer given a font and starting position
- Added operating system calls in the main game loop needed for enforcing a frame rate.

## Notes

- Only monospaced fonts work currently. More work needs to be done to correctly render normal fonts.
- Fixed a bug with bitmap rendering incorrectly pulling the dest pixel value that was causing incorrect alpha blending.